### PR TITLE
Colorize the issue's attachment by github search query

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c874dad16816f86f49476f6f70ac82e282ec8c7c256b2b187461ad10cdef9e06"
+  name = "github.com/karrick/tparse"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "01217819bead9d238dc62e8a054ca09486e2c1a1"
+  version = "v2.6.1"
+
+[[projects]]
   digest = "1:7aefb397a53fc437c90f0fdb3e1419c751c5a3a165ced52325d5d797edf1aca6"
   name = "github.com/moul/http2curl"
   packages = ["."]
@@ -68,18 +76,18 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "915654e7eabcea33ae277abbecf52f0d8b7a9fdc"
+  revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
 
 [[projects]]
   branch = "master"
-  digest = "1:e007b54f54cbd4214aa6d97a67d57bc2539991adb4e22ea92c482bbece8de469"
+  digest = "1:c664d4451770ebc9ab63d54bccb9e4f2c6106cde7e566ea02889930b836c7d4c"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "5dab4167f31cbd76b407f1486c86b40748bc5073"
+  revision = "3e8b2be1363542a95c52ea0796d4a40dacfb5b95"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -134,6 +142,7 @@
   input-imports = [
     "github.com/ashwanthkumar/slack-go-webhook",
     "github.com/google/go-github/github",
+    "github.com/karrick/tparse",
     "golang.org/x/oauth2",
     "gopkg.in/urfave/cli.v2",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,6 +37,10 @@
   name = "github.com/ashwanthkumar/slack-go-webhook"
   version = "v0.3"
 
+[[constraint]]
+  name = "github.com/karrick/tparse"
+  version = "v2.6.1"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 		},
 	}
 	app.Action = func(c *cli.Context) error {
-		query := c.String("query")
+		query := convertRelativeTimeQuery(c.String("query"))
 
 		gc := &githubClient{
 			apiURL: c.String("github-api-url"),
@@ -84,7 +84,7 @@ func main() {
 
 		warningIssues := []github.Issue{}
 		if wf := c.String("warning-filter"); wf != "" {
-			warningIssues, err = gc.searchGithubIssues(query + " " + wf)
+			warningIssues, err = gc.searchGithubIssues(query + " " + convertRelativeTimeQuery(wf))
 			if err != nil {
 				return err
 			}
@@ -92,7 +92,7 @@ func main() {
 
 		dangerIssues := []github.Issue{}
 		if df := c.String("danger-filter"); df != "" {
-			dangerIssues, err = gc.searchGithubIssues(query + " " + df)
+			dangerIssues, err = gc.searchGithubIssues(query + " " + convertRelativeTimeQuery(df))
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/google/go-github/github"
 	cli "gopkg.in/urfave/cli.v2"
@@ -15,7 +14,7 @@ func main() {
 	app := &cli.App{}
 	app.Name = "notify-issues-to-slack"
 	app.Version = fmt.Sprintf("%s (rev: %s/%s)", version, revision, runtime.Version())
-	app.UsageText = "notify-issues-to-slack -github-token=... -slack-webhook-url=... -query=... [-danger-over=...] [-warning-over=...] [-channel=...] [-text=...] [-username=...] [-icon-emoji=...] [-github-api-url=...]"
+	app.UsageText = "notify-issues-to-slack -github-token=... -slack-webhook-url=... -query=... [-danger-filter=...] [-warning-filter=...] [-channel=...] [-text=...] [-username=...] [-icon-emoji=...] [-github-api-url=...]"
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:  "github-token",
@@ -30,16 +29,8 @@ func main() {
 			Usage: "Query to search Github issues",
 		},
 		&cli.StringFlag{
-			Name:  "danger-over",
-			Usage: "Colorize the issue's attachment danger",
-		},
-		&cli.StringFlag{
 			Name:  "danger-filter",
 			Usage: "Colorize the issue's attachment danger. You can use Github search queries",
-		},
-		&cli.StringFlag{
-			Name:  "warning-over",
-			Usage: "Colorize the issue's attachment warning",
 		},
 		&cli.StringFlag{
 			Name:  "warning-filter",
@@ -98,20 +89,6 @@ func main() {
 			}
 		}
 
-		var dangerOver, warningOver time.Duration
-		if c.String("danger-over") != "" {
-			dangerOver, err = time.ParseDuration(c.String("danger-over"))
-			if err != nil {
-				return err
-			}
-		}
-		if c.String("warning-over") != "" {
-			warningOver, err = time.ParseDuration(c.String("warning-over"))
-			if err != nil {
-				return err
-			}
-		}
-
 		sc := &slackClient{webhookURL: c.String("slack-webhook-url")}
 		sc.postIssuesToSlack(issues, warningIssues, dangerIssues, &slackPostOptions{
 			Text:            c.String("text"),
@@ -119,8 +96,6 @@ func main() {
 			Channel:         c.String("channel"),
 			Username:        c.String("username"),
 			IconEmoji:       c.String("icon-emoji"),
-			DangerOver:      &dangerOver,
-			WarningOver:     &warningOver,
 		})
 		return nil
 	}

--- a/query_converter.go
+++ b/query_converter.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/karrick/tparse"
+)
+
+var (
+	// e.g.) created:<=now-7d, then $1 is `created:<=` and $2 is `now-7d`.
+	// See Also: https://help.github.com/en/articles/understanding-the-search-syntax#query-for-dates
+	relativeTimeQueryReg = regexp.MustCompile(`^((?:created|updated|closed|merged):[<>=]*)(.+)$`)
+)
+
+func convertRelativeTimeQuery(query string) string {
+	conditions := strings.Split(query, " ")
+	convertedConditions := []string{}
+	for _, c := range conditions {
+		matches := relativeTimeQueryReg.FindStringSubmatch(c)
+		if len(matches) != 3 {
+			convertedConditions = append(convertedConditions, c)
+		} else {
+			absolute, err := tparse.ParseNow(time.RFC3339, matches[2])
+			if err != nil {
+				convertedConditions = append(convertedConditions, c)
+			} else {
+				convertedConditions = append(convertedConditions, matches[1]+absolute.UTC().Format(time.RFC3339))
+			}
+		}
+	}
+	return strings.Join(convertedConditions, " ")
+}

--- a/slack.go
+++ b/slack.go
@@ -29,20 +29,24 @@ const (
 	defaultIssueTextFormat = "{{.GetTitle}} @{{if .GetAssignee }}{{.GetAssignee.GetLogin}}{{else}}{{.GetUser.GetLogin}}{{end}}"
 )
 
-func (s *slackClient) postIssuesToSlack(issues []github.Issue, opt *slackPostOptions) error {
+func (s *slackClient) postIssuesToSlack(issues []github.Issue, warningIssues []github.Issue, dangerIssues []github.Issue, opt *slackPostOptions) error {
 	issueTextFormat := opt.IssueTextFormat
 	if issueTextFormat == "" {
 		issueTextFormat = defaultIssueTextFormat
 	}
 
+	warningIssueMap := s.makeIssueExistsMap(warningIssues)
+	dangerIssueMap := s.makeIssueExistsMap(dangerIssues)
+
 	attachments := []slack.Attachment{}
 	for _, i := range issues {
+		i.GetID()
 		issueText, err := s.formatIssueText(issueTextFormat, i)
 		if err != nil {
 			fmt.Println(err)
 			return err
 		}
-		color := s.getColorByIssue(i, opt.DangerOver, opt.WarningOver)
+		color := s.getColorByIssue(i, warningIssueMap, dangerIssueMap)
 		a := slack.Attachment{
 			Title:     &issueText,
 			TitleLink: i.HTMLURL,
@@ -103,15 +107,20 @@ func (s *slackClient) formatIssueText(format string, issue github.Issue) (string
 	return text.String(), nil
 }
 
-func (s *slackClient) getColorByIssue(issue github.Issue, dangerOver *time.Duration, warningOver *time.Duration) string {
-	durationFromIssueCreated := time.Now().Sub(issue.GetCreatedAt())
-
-	color := "good"
-	if dangerOver != nil && durationFromIssueCreated.Hours() > dangerOver.Hours() {
-		color = "danger"
-	} else if warningOver != nil && durationFromIssueCreated.Hours() > warningOver.Hours() {
-		color = "warning"
+func (s *slackClient) getColorByIssue(issue github.Issue, warningIssueMap map[int64]bool, dangerIssueMap map[int64]bool) string {
+	if dangerIssueMap[issue.GetID()] {
+		return "danger"
+	} else if warningIssueMap[issue.GetID()] {
+		return "warning"
+	} else {
+		return "good"
 	}
+}
 
-	return color
+func (s *slackClient) makeIssueExistsMap(issues []github.Issue) map[int64]bool {
+	issueExistsMap := map[int64]bool{}
+	for _, i := range issues {
+		issueExistsMap[i.GetID()] = true
+	}
+	return issueExistsMap
 }

--- a/slack.go
+++ b/slack.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
-	"time"
 
 	slack "github.com/ashwanthkumar/slack-go-webhook"
 	"github.com/google/go-github/github"
@@ -21,8 +20,6 @@ type slackPostOptions struct {
 	Channel         string
 	Username        string
 	IconEmoji       string
-	DangerOver      *time.Duration
-	WarningOver     *time.Duration
 }
 
 const (

--- a/slack.go
+++ b/slack.go
@@ -37,7 +37,6 @@ func (s *slackClient) postIssuesToSlack(issues []github.Issue, warningIssues []g
 
 	attachments := []slack.Attachment{}
 	for _, i := range issues {
-		i.GetID()
 		issueText, err := s.formatIssueText(issueTextFormat, i)
 		if err != nil {
 			fmt.Println(err)

--- a/vendor/github.com/karrick/tparse/.gitignore
+++ b/vendor/github.com/karrick/tparse/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/karrick/tparse/LICENSE
+++ b/vendor/github.com/karrick/tparse/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Karrick McDermott
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/karrick/tparse/README.md
+++ b/vendor/github.com/karrick/tparse/README.md
@@ -1,0 +1,124 @@
+# tparse
+
+`Parse` will return the time corresponding to the layout and value.
+It also parses floating point epoch values, and values of "now",
+"now+DURATION", and "now-DURATION".
+
+In addition to the duration abbreviations recognized by
+`time.ParseDuration`, tparse recognizes various tokens for days,
+weeks, months, and years, as well as tokens for seconds, minutes, and
+hours.
+
+Like `time.ParseDuration`, it accepts multiple fractional scalars, so
+"now+1.5days-3.21hours" is evaluated properly.
+
+## Documentation
+
+In addition to this handy README.md file, documentation is available
+in godoc format at
+[![GoDoc](https://godoc.org/github.com/karrick/tparse?status.svg)](https://godoc.org/github.com/karrick/tparse).
+
+## Examples
+
+### ParseNow
+
+`ParseNow` can parse time values that are relative to the current
+time, by specifying a string starting with "now", a '+' or '-' byte,
+followed by a time duration.
+
+```Go
+    package main
+
+    import (
+        "fmt"
+        "os"
+        "time"
+        "github.com/karrick/tparse"
+    )
+
+    func main() {
+        actual, err := tparse.ParseNow(time.RFC3339, "now+1d-3w4mo+7y6h4m")
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "error: %s\n", err)
+            os.Exit(1)
+        }
+        fmt.Printf("time is: %s\n", actual)
+    }
+```
+
+### ParseWithMap
+
+`ParseWithMap` can parse time values that use a base time other than "now".
+
+```Go
+    package main
+
+    import (
+        "fmt"
+        "os"
+        "time"
+        "github.com/karrick/tparse"
+    )
+
+    func main() {
+        m := make(map[string]time.Time)
+        m["end"] = time.Now()
+
+        start, err := tparse.ParseWithMap(time.RFC3339, "end-12h", m)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "error: %s\n", err)
+            os.Exit(1)
+        }
+
+        fmt.Printf("start: %s; end: %s\n", start, end)
+    }
+```
+
+### AddDuration
+
+`AddDuration` is used to compute the value of a duration string and
+add it to a known time. This function is used by the other library
+functions to parse all duration strings.
+
+The following tokens may be used to specify the respective unit of
+time:
+
+ * Nanosecond: ns
+ * Microsecond: us, µs (U+00B5 = micro symbol), μs (U+03BC = Greek letter mu)
+ * Millisecond: ms
+ * Second: s, sec, second, seconds
+ * Minute: m, min, minute, minutes
+ * Hour: h, hr, hour, hours
+ * Day: d, day, days
+ * Week: w, wk, week, weeks
+ * Month: mo, mon, month, months
+ * Year: y, yr, year, years
+
+```Go
+    package main
+
+    import (
+        "fmt"
+        "os"
+        "time"
+
+        "github.com/karrick/tparse"
+    )
+
+    func main() {
+        now := time.Now()
+        another, err := tparse.AddDuration(now, "+1d3w4mo-7y6h4m")
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "error: %s\n", err)
+            os.Exit(1)
+        }
+
+        fmt.Printf("time is: %s\n", another)
+    }
+```
+
+## Benchmark against goparsetime
+
+```Bash
+GO111MODULE=on go test -bench=. -tags goparsetime
+```

--- a/vendor/github.com/karrick/tparse/go.mod
+++ b/vendor/github.com/karrick/tparse/go.mod
@@ -1,0 +1,1 @@
+module github.com/karrick/tparse

--- a/vendor/github.com/karrick/tparse/tparse.go
+++ b/vendor/github.com/karrick/tparse/tparse.go
@@ -1,0 +1,172 @@
+package tparse
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// Parse will return the time value corresponding to the specified layout and value.  It also parses
+// floating point and integer epoch values.
+func Parse(layout, value string) (time.Time, error) {
+	return ParseWithMap(layout, value, make(map[string]time.Time))
+}
+
+// ParseNow will return the time value corresponding to the specified layout and value.  It also
+// parses floating point and integer epoch values.  It recognizes the special string `now` and
+// replaces that with the time ParseNow is called.  This allows a suffix adding or subtracting
+// various values from the base time.  For instance, ParseNow(time.ANSIC, "now+1d") will return a
+// time corresponding to 24 hours from the moment the function is invoked.
+//
+// In addition to the duration abbreviations recognized by time.ParseDuration, it recognizes various
+// tokens for days, weeks, months, and years.
+//
+//	package main
+//
+//	import (
+//		"fmt"
+//		"os"
+//		"time"
+//
+//		"github.com/karrick/tparse"
+//	)
+//
+//	func main() {
+//		actual, err := tparse.ParseNow(time.RFC3339, "now+1d3w4mo7y6h4m")
+//		if err != nil {
+//			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+//			os.Exit(1)
+//		}
+//
+//		fmt.Printf("time is: %s\n", actual)
+//	}
+func ParseNow(layout, value string) (time.Time, error) {
+	m := map[string]time.Time{"now": time.Now()}
+	return ParseWithMap(layout, value, m)
+}
+
+// ParseWithMap will return the time value corresponding to the specified layout and value.  It also
+// parses floating point and integer epoch values.  It accepts a map of strings to time.Time values,
+// and if the value string starts with one of the keys in the map, it replaces the string with the
+// corresponding time.Time value.
+//
+//	package main
+//
+//	import (
+//		"fmt"
+//		"os"
+//		"time"
+//
+//		"github.com/karrick/tparse"
+//	)
+//
+//	func main() {
+//		m := make(map[string]time.Time)
+//		m["start"] = start
+//
+//		end, err := tparse.ParseWithMap(time.RFC3339, "start+8h", m)
+//		if err != nil {
+//			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+//			os.Exit(1)
+//		}
+//
+//		fmt.Printf("start: %s; end: %s\n", start, end)
+//	}
+func ParseWithMap(layout, value string, dict map[string]time.Time) (time.Time, error) {
+	if epoch, err := strconv.ParseFloat(value, 64); err == nil && epoch >= 0 {
+		trunc := math.Trunc(epoch)
+		nanos := fractionToNanos(epoch - trunc)
+		return time.Unix(int64(trunc), int64(nanos)), nil
+	}
+	var base time.Time
+	var y, m, d int
+	var duration time.Duration
+	var direction = 1
+	var err error
+
+	for k, v := range dict {
+		if strings.HasPrefix(value, k) {
+			base = v
+			if len(value) > len(k) {
+				// maybe has +, -
+				switch dir := value[len(k)]; dir {
+				case '+':
+					// no-op
+				case '-':
+					direction = -1
+				default:
+					return base, fmt.Errorf("expected '+' or '-': %q", dir)
+				}
+				var nv string
+				y, m, d, nv = ymd(value[len(k)+1:])
+				if len(nv) > 0 {
+					duration, err = time.ParseDuration(nv)
+					if err != nil {
+						return base, err
+					}
+				}
+			}
+			if direction < 0 {
+				y = -y
+				m = -m
+				d = -d
+			}
+			return base.Add(time.Duration(int(duration)*direction)).AddDate(y, m, d), nil
+		}
+	}
+	return time.Parse(layout, value)
+}
+
+func fractionToNanos(fraction float64) int64 {
+	return int64(fraction * float64(time.Second/time.Nanosecond))
+}
+
+func ymd(value string) (int, int, int, string) {
+	// alternating numbers and strings
+	var y, m, d int
+	var accum int     // accumulates digits
+	var unit []byte   // accumulates units
+	var unproc []byte // accumulate unprocessed durations to return
+
+	unitComplete := func() {
+		// NOTE: compare byte slices because some units, i.e. ms, are multi-rune
+		if bytes.Equal(unit, []byte{'d'}) || bytes.Equal(unit, []byte{'d', 'a', 'y'}) || bytes.Equal(unit, []byte{'d', 'a', 'y', 's'}) {
+			d += accum
+		} else if bytes.Equal(unit, []byte{'w'}) || bytes.Equal(unit, []byte{'w', 'e', 'e', 'k'}) || bytes.Equal(unit, []byte{'w', 'e', 'e', 'k', 's'}) {
+			d += 7 * accum
+		} else if bytes.Equal(unit, []byte{'m', 'o'}) || bytes.Equal(unit, []byte{'m', 'o', 'n'}) || bytes.Equal(unit, []byte{'m', 'o', 'n', 't', 'h'}) || bytes.Equal(unit, []byte{'m', 'o', 'n', 't', 'h', 's'}) || bytes.Equal(unit, []byte{'m', 't', 'h'}) || bytes.Equal(unit, []byte{'m', 'n'}) {
+			m += accum
+		} else if bytes.Equal(unit, []byte{'y'}) || bytes.Equal(unit, []byte{'y', 'e', 'a', 'r'}) || bytes.Equal(unit, []byte{'y', 'e', 'a', 'r', 's'}) {
+			y += accum
+		} else {
+			unproc = append(append(unproc, strconv.Itoa(accum)...), unit...)
+		}
+	}
+
+	expectDigit := true
+	for _, rune := range value {
+		if unicode.IsDigit(rune) {
+			if expectDigit {
+				accum = accum*10 + int(rune-'0')
+			} else {
+				unitComplete()
+				unit = unit[:0]
+				accum = int(rune - '0')
+			}
+			continue
+		}
+		unit = append(unit, string(rune)...)
+		expectDigit = false
+	}
+	if len(unit) > 0 {
+		unitComplete()
+		accum = 0
+		unit = unit[:0]
+	}
+	// log.Printf("y: %d; m: %d; d: %d; nv: %q", y, m, d, unproc)
+	return y, m, d, string(unproc)
+}

--- a/vendor/golang.org/x/oauth2/README.md
+++ b/vendor/golang.org/x/oauth2/README.md
@@ -19,57 +19,6 @@ See godoc for further documentation and examples.
 * [godoc.org/golang.org/x/oauth2](http://godoc.org/golang.org/x/oauth2)
 * [godoc.org/golang.org/x/oauth2/google](http://godoc.org/golang.org/x/oauth2/google)
 
-
-## App Engine
-
-In change 96e89be (March 2015), we removed the `oauth2.Context2` type in favor
-of the [`context.Context`](https://golang.org/x/net/context#Context) type from
-the `golang.org/x/net/context` package. Later replaced by the standard `context` package
-of the [`context.Context`](https://golang.org/pkg/context#Context) type.
-
-
-This means it's no longer possible to use the "Classic App Engine"
-`appengine.Context` type with the `oauth2` package. (You're using
-Classic App Engine if you import the package `"appengine"`.)
-
-To work around this, you may use the new `"google.golang.org/appengine"`
-package. This package has almost the same API as the `"appengine"` package,
-but it can be fetched with `go get` and used on "Managed VMs" and well as
-Classic App Engine.
-
-See the [new `appengine` package's readme](https://github.com/golang/appengine#updating-a-go-app-engine-app)
-for information on updating your app.
-
-If you don't want to update your entire app to use the new App Engine packages,
-you may use both sets of packages in parallel, using only the new packages
-with the `oauth2` package.
-
-```go
-import (
-	"context"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
-	newappengine "google.golang.org/appengine"
-	newurlfetch "google.golang.org/appengine/urlfetch"
-
-	"appengine"
-)
-
-func handler(w http.ResponseWriter, r *http.Request) {
-	var c appengine.Context = appengine.NewContext(r)
-	c.Infof("Logging a message with the old package")
-
-	var ctx context.Context = newappengine.NewContext(r)
-	client := &http.Client{
-		Transport: &oauth2.Transport{
-			Source: google.AppEngineTokenSource(ctx, "scope"),
-			Base:   &newurlfetch.Transport{Context: ctx},
-		},
-	}
-	client.Get("...")
-}
-```
-
 ## Policy for new packages
 
 We no longer accept new provider-specific packages in this repo. For

--- a/vendor/golang.org/x/oauth2/internal/token.go
+++ b/vendor/golang.org/x/oauth2/internal/token.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -77,6 +78,9 @@ func (e *tokenJSON) expiry() (t time.Time) {
 type expirationTime int32
 
 func (e *expirationTime) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == "null" {
+		return nil
+	}
 	var n json.Number
 	err := json.Unmarshal(b, &n)
 	if err != nil {
@@ -90,102 +94,71 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-var brokenAuthHeaderProviders = []string{
-	"https://accounts.google.com/",
-	"https://api.codeswholesale.com/oauth/token",
-	"https://api.dropbox.com/",
-	"https://api.dropboxapi.com/",
-	"https://api.instagram.com/",
-	"https://api.netatmo.net/",
-	"https://api.odnoklassniki.ru/",
-	"https://api.pushbullet.com/",
-	"https://api.soundcloud.com/",
-	"https://api.twitch.tv/",
-	"https://id.twitch.tv/",
-	"https://app.box.com/",
-	"https://api.box.com/",
-	"https://connect.stripe.com/",
-	"https://login.mailchimp.com/",
-	"https://login.microsoftonline.com/",
-	"https://login.salesforce.com/",
-	"https://login.windows.net",
-	"https://login.live.com/",
-	"https://login.live-int.com/",
-	"https://oauth.sandbox.trainingpeaks.com/",
-	"https://oauth.trainingpeaks.com/",
-	"https://oauth.vk.com/",
-	"https://openapi.baidu.com/",
-	"https://slack.com/",
-	"https://test-sandbox.auth.corp.google.com",
-	"https://test.salesforce.com/",
-	"https://user.gini.net/",
-	"https://www.douban.com/",
-	"https://www.googleapis.com/",
-	"https://www.linkedin.com/",
-	"https://www.strava.com/oauth/",
-	"https://www.wunderlist.com/oauth/",
-	"https://api.patreon.com/",
-	"https://sandbox.codeswholesale.com/oauth/token",
-	"https://api.sipgate.com/v1/authorization/oauth",
-	"https://api.medium.com/v1/tokens",
-	"https://log.finalsurge.com/oauth/token",
-	"https://multisport.todaysplan.com.au/rest/oauth/access_token",
-	"https://whats.todaysplan.com.au/rest/oauth/access_token",
-	"https://stackoverflow.com/oauth/access_token",
-	"https://account.health.nokia.com",
-	"https://accounts.zoho.com",
-	"https://gitter.im/login/oauth/token",
-	"https://openid-connect.onelogin.com/oidc",
-	"https://api.dailymotion.com/oauth/token",
+// RegisterBrokenAuthHeaderProvider previously did something. It is now a no-op.
+//
+// Deprecated: this function no longer does anything. Caller code that
+// wants to avoid potential extra HTTP requests made during
+// auto-probing of the provider's auth style should set
+// Endpoint.AuthStyle.
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {}
+
+// AuthStyle is a copy of the golang.org/x/oauth2 package's AuthStyle type.
+type AuthStyle int
+
+const (
+	AuthStyleUnknown  AuthStyle = 0
+	AuthStyleInParams AuthStyle = 1
+	AuthStyleInHeader AuthStyle = 2
+)
+
+// authStyleCache is the set of tokenURLs we've successfully used via
+// RetrieveToken and which style auth we ended up using.
+// It's called a cache, but it doesn't (yet?) shrink. It's expected that
+// the set of OAuth2 servers a program contacts over time is fixed and
+// small.
+var authStyleCache struct {
+	sync.Mutex
+	m map[string]AuthStyle // keyed by tokenURL
 }
 
-// brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.
-var brokenAuthHeaderDomains = []string{
-	".auth0.com",
-	".force.com",
-	".myshopify.com",
-	".okta.com",
-	".oktapreview.com",
+// ResetAuthCache resets the global authentication style cache used
+// for AuthStyleUnknown token requests.
+func ResetAuthCache() {
+	authStyleCache.Lock()
+	defer authStyleCache.Unlock()
+	authStyleCache.m = nil
 }
 
-func RegisterBrokenAuthHeaderProvider(tokenURL string) {
-	brokenAuthHeaderProviders = append(brokenAuthHeaderProviders, tokenURL)
+// lookupAuthStyle reports which auth style we last used with tokenURL
+// when calling RetrieveToken and whether we have ever done so.
+func lookupAuthStyle(tokenURL string) (style AuthStyle, ok bool) {
+	authStyleCache.Lock()
+	defer authStyleCache.Unlock()
+	style, ok = authStyleCache.m[tokenURL]
+	return
 }
 
-// providerAuthHeaderWorks reports whether the OAuth2 server identified by the tokenURL
-// implements the OAuth2 spec correctly
-// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
-// In summary:
-// - Reddit only accepts client secret in the Authorization header
-// - Dropbox accepts either it in URL param or Auth header, but not both.
-// - Google only accepts URL param (not spec compliant?), not Auth header
-// - Stripe only accepts client secret in Auth header with Bearer method, not Basic
-func providerAuthHeaderWorks(tokenURL string) bool {
-	for _, s := range brokenAuthHeaderProviders {
-		if strings.HasPrefix(tokenURL, s) {
-			// Some sites fail to implement the OAuth2 spec fully.
-			return false
-		}
+// setAuthStyle adds an entry to authStyleCache, documented above.
+func setAuthStyle(tokenURL string, v AuthStyle) {
+	authStyleCache.Lock()
+	defer authStyleCache.Unlock()
+	if authStyleCache.m == nil {
+		authStyleCache.m = make(map[string]AuthStyle)
 	}
-
-	if u, err := url.Parse(tokenURL); err == nil {
-		for _, s := range brokenAuthHeaderDomains {
-			if strings.HasSuffix(u.Host, s) {
-				return false
-			}
-		}
-	}
-
-	// Assume the provider implements the spec properly
-	// otherwise. We can add more exceptions as they're
-	// discovered. We will _not_ be adding configurable hooks
-	// to this package to let users select server bugs.
-	return true
+	authStyleCache.m[tokenURL] = v
 }
 
-func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string, v url.Values) (*Token, error) {
-	bustedAuth := !providerAuthHeaderWorks(tokenURL)
-	if bustedAuth {
+// newTokenRequest returns a new *http.Request to retrieve a new token
+// from tokenURL using the provided clientID, clientSecret, and POST
+// body parameters.
+//
+// inParams is whether the clientID & clientSecret should be encoded
+// as the POST body. An 'inParams' value of true means to send it in
+// the POST body (along with any values in v); false means to send it
+// in the Authorization header.
+func newTokenRequest(tokenURL, clientID, clientSecret string, v url.Values, authStyle AuthStyle) (*http.Request, error) {
+	if authStyle == AuthStyleInParams {
+		v = cloneURLValues(v)
 		if clientID != "" {
 			v.Set("client_id", clientID)
 		}
@@ -198,15 +171,70 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if !bustedAuth {
+	if authStyle == AuthStyleInHeader {
 		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
 	}
+	return req, nil
+}
+
+func cloneURLValues(v url.Values) url.Values {
+	v2 := make(url.Values, len(v))
+	for k, vv := range v {
+		v2[k] = append([]string(nil), vv...)
+	}
+	return v2
+}
+
+func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string, v url.Values, authStyle AuthStyle) (*Token, error) {
+	needsAuthStyleProbe := authStyle == 0
+	if needsAuthStyleProbe {
+		if style, ok := lookupAuthStyle(tokenURL); ok {
+			authStyle = style
+			needsAuthStyleProbe = false
+		} else {
+			authStyle = AuthStyleInHeader // the first way we'll try
+		}
+	}
+	req, err := newTokenRequest(tokenURL, clientID, clientSecret, v, authStyle)
+	if err != nil {
+		return nil, err
+	}
+	token, err := doTokenRoundTrip(ctx, req)
+	if err != nil && needsAuthStyleProbe {
+		// If we get an error, assume the server wants the
+		// clientID & clientSecret in a different form.
+		// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
+		// In summary:
+		// - Reddit only accepts client secret in the Authorization header
+		// - Dropbox accepts either it in URL param or Auth header, but not both.
+		// - Google only accepts URL param (not spec compliant?), not Auth header
+		// - Stripe only accepts client secret in Auth header with Bearer method, not Basic
+		//
+		// We used to maintain a big table in this code of all the sites and which way
+		// they went, but maintaining it didn't scale & got annoying.
+		// So just try both ways.
+		authStyle = AuthStyleInParams // the second way we'll try
+		req, _ = newTokenRequest(tokenURL, clientID, clientSecret, v, authStyle)
+		token, err = doTokenRoundTrip(ctx, req)
+	}
+	if needsAuthStyleProbe && err == nil {
+		setAuthStyle(tokenURL, authStyle)
+	}
+	// Don't overwrite `RefreshToken` with an empty value
+	// if this was a token refreshing request.
+	if token != nil && token.RefreshToken == "" {
+		token.RefreshToken = v.Get("refresh_token")
+	}
+	return token, err
+}
+
+func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 	r, err := ctxhttp.Do(ctx, ContextClient(ctx), req)
 	if err != nil {
 		return nil, err
 	}
-	defer r.Body.Close()
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	r.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}
@@ -232,7 +260,7 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 			Raw:          vals,
 		}
 		e := vals.Get("expires_in")
-		if e == "" {
+		if e == "" || e == "null" {
 			// TODO(jbd): Facebook's OAuth2 implementation is broken and
 			// returns expires_in field in expires. Remove the fallback to expires,
 			// when Facebook fixes their implementation.
@@ -256,13 +284,8 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 		}
 		json.Unmarshal(body, &token.Raw) // no error checks for optional fields
 	}
-	// Don't overwrite `RefreshToken` with an empty value
-	// if this was a token refreshing request.
-	if token.RefreshToken == "" {
-		token.RefreshToken = v.Get("refresh_token")
-	}
 	if token.AccessToken == "" {
-		return token, errors.New("oauth2: server response missing access_token")
+		return nil, errors.New("oauth2: server response missing access_token")
 	}
 	return token, nil
 }

--- a/vendor/golang.org/x/oauth2/oauth2.go
+++ b/vendor/golang.org/x/oauth2/oauth2.go
@@ -26,17 +26,13 @@ import (
 // Deprecated: Use context.Background() or context.TODO() instead.
 var NoContext = context.TODO()
 
-// RegisterBrokenAuthHeaderProvider registers an OAuth2 server
-// identified by the tokenURL prefix as an OAuth2 implementation
-// which doesn't support the HTTP Basic authentication
-// scheme to authenticate with the authorization server.
-// Once a server is registered, credentials (client_id and client_secret)
-// will be passed as parameters in the request body rather than being present
-// in the Authorization header.
-// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
-func RegisterBrokenAuthHeaderProvider(tokenURL string) {
-	internal.RegisterBrokenAuthHeaderProvider(tokenURL)
-}
+// RegisterBrokenAuthHeaderProvider previously did something. It is now a no-op.
+//
+// Deprecated: this function no longer does anything. Caller code that
+// wants to avoid potential extra HTTP requests made during
+// auto-probing of the provider's auth style should set
+// Endpoint.AuthStyle.
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {}
 
 // Config describes a typical 3-legged OAuth2 flow, with both the
 // client application information and the server's endpoint URLs.
@@ -71,12 +67,37 @@ type TokenSource interface {
 	Token() (*Token, error)
 }
 
-// Endpoint contains the OAuth 2.0 provider's authorization and token
+// Endpoint represents an OAuth 2.0 provider's authorization and token
 // endpoint URLs.
 type Endpoint struct {
 	AuthURL  string
 	TokenURL string
+
+	// AuthStyle optionally specifies how the endpoint wants the
+	// client ID & client secret sent. The zero value means to
+	// auto-detect.
+	AuthStyle AuthStyle
 }
+
+// AuthStyle represents how requests for tokens are authenticated
+// to the server.
+type AuthStyle int
+
+const (
+	// AuthStyleAutoDetect means to auto-detect which authentication
+	// style the provider wants by trying both ways and caching
+	// the successful way for the future.
+	AuthStyleAutoDetect AuthStyle = 0
+
+	// AuthStyleInParams sends the "client_id" and "client_secret"
+	// in the POST body as application/x-www-form-urlencoded parameters.
+	AuthStyleInParams AuthStyle = 1
+
+	// AuthStyleInHeader sends the client_id and client_password
+	// using HTTP Basic Authorization. This is an optional style
+	// described in the OAuth2 RFC 6749 section 2.3.1.
+	AuthStyleInHeader AuthStyle = 2
+)
 
 var (
 	// AccessTypeOnline and AccessTypeOffline are options passed

--- a/vendor/golang.org/x/oauth2/token.go
+++ b/vendor/golang.org/x/oauth2/token.go
@@ -154,7 +154,7 @@ func tokenFromInternal(t *internal.Token) *Token {
 // This token is then mapped from *internal.Token into an *oauth2.Token which is returned along
 // with an error..
 func retrieveToken(ctx context.Context, c *Config, v url.Values) (*Token, error) {
-	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, v)
+	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, v, internal.AuthStyle(c.Endpoint.AuthStyle))
 	if err != nil {
 		if rErr, ok := err.(*internal.RetrieveError); ok {
 			return nil, (*RetrieveError)(rErr)


### PR DESCRIPTION
Before, we can colorize issues by warning-over and danger-over options. But this option only let us to specify condition using issue's created.

This pull request make it possible to colorize issue by specifying github queries to warning-filter and danger-filter.  Like following

```
notify-issues-to-slack -query "repo:shibayu36/notify-issues-to-slack state:open" -danger-filter="created:<now-1mo" warning-filter="created:<now-1w"
```